### PR TITLE
Switch to gp3 volume type as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Type: `string`
 
 Default: `"t3.micro"`
 
+### <a name="input_root_volume_type"></a> [root\_volume\_type](#input\_root\_volume\_type)
+
+Description: The type of the EBS root volume
+
+Type: `string`
+
+Default: `"gp3"`
+
 ### <a name="input_healthcheck_url"></a> [healthcheck\_url](#input\_healthcheck\_url)
 
 Description: Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,8 @@ module "environment" {
   loadbalancer_certificate_arn = module.acm.acm_certificate_arn
   loadbalancer_ssl_policy      = var.loadbalancer_ssl_policy
 
-  instance_type = var.instance_type
+  instance_type    = var.instance_type
+  root_volume_type = var.root_volume_type
 
   healthcheck_url                      = var.healthcheck_url
   healthcheck_interval                 = var.healthcheck_interval

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "instance_type" {
   description = "Instances type"
 }
 
+variable "root_volume_type" {
+  type        = string
+  default     = "gp3"
+  description = "The type of the EBS root volume"
+}
+
 variable "healthcheck_url" {
   type        = string
   default     = "/healthz"


### PR DESCRIPTION
This parameter has to be set on order to switch from launch configuration to launch templates

Link: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-autoscaling-launch-templates.html#environments-cfg-autoscaling-launch-templates-options