### PR TITLE
Set minimum defaults for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Description: Instances type
 
 Type: `string`
 
-Default: `"t3.micro"`
+Default: `"t3.small"`
 
 ### <a name="input_root_volume_type"></a> [root\_volume\_type](#input\_root\_volume\_type)
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "loadbalancer_ssl_policy" {
 
 variable "instance_type" {
   type        = string
-  default     = "t3.micro"
+  default     = "t3.small"
   description = "Instances type"
 }
 


### PR DESCRIPTION
Minumum recomended instance size is 2Gb RAM